### PR TITLE
Some bugs fixed.

### DIFF
--- a/LegacyBar.Sample/FragmentTabActivity.cs
+++ b/LegacyBar.Sample/FragmentTabActivity.cs
@@ -53,15 +53,15 @@ namespace LegacyBar.Sample
             _tabsAdapter = new TabsAdapter(this, _tabHost, _viewPager);
 
 
-            ActionBar = FindViewById<Library.Bar.LegacyBar>(Resource.Id.actionbar);
-            ActionBar.Title = "Look Fragments";
+            LegacyBar = FindViewById<Library.Bar.LegacyBar>(Resource.Id.actionbar);
+            LegacyBar.Title = "Look Fragments";
             AddHomeAction(typeof (HomeActivity), Resource.Drawable.icon);
 
 
             var action = new MenuItemLegacyBarAction(this, this, Resource.Id.menu_search,
                                                      Resource.Drawable.ic_action_search_dark,
                                                      Resource.String.menu_string_search);
-            ActionBar.AddAction(action);
+            LegacyBar.AddAction(action);
 
 
             TabHost.TabSpec spec = _tabHost.NewTabSpec("tv");

--- a/LegacyBar.Sample/HomeActivity.cs
+++ b/LegacyBar.Sample/HomeActivity.cs
@@ -60,6 +60,8 @@ namespace LegacyBar.Sample
              */
 
             //always put these 2 in there since they are NOT in my menu.xml
+            MenuId = Resource.Menu.mainmenu;
+
             LegacyBarAction shareAction = new DefaultLegacyBarAction(this, CreateShareIntent(),
                                                                      LegacyBar.LightIcons ? Resource.Drawable.ic_action_sort : Resource.Drawable.ic_action_sort_dark)
                                               {


### PR DESCRIPTION
Use `LegacyBar` instead of `ActionBar` in `FragmentTabActivity`.https://github.com/aaronmix/MonoDroid.ActionBar/commit/1a6e1680674cf77e68133fec0b2eee54d068fe24

Add the missing `MenuId` in `HomeActivity`. https://github.com/aaronmix/MonoDroid.ActionBar/commit/a3005ff3497e6f5d37c5954a56f9636eaac9ff6f This will cause exception when the user clicks the physical menu button. My device is Motoroal Droid. It runs Android 4.0 but still has physical menu button.
